### PR TITLE
fix(procurement): Update year logic to include April 2026

### DIFF
--- a/loss-sales-tracker.html
+++ b/loss-sales-tracker.html
@@ -319,9 +319,9 @@
             'September': 9, 'October': 10, 'November': 11, 'December': 12
         };
         
-        // Determine year for each month (2026 for Jan-Mar, 2025 for rest)
+        // Determine year for each month (2026 for Jan-Apr, 2025 for rest)
         function getYearForMonth(month) {
-            if (month === 'January' || month === 'February' || month === 'March') {
+            if (month === 'January' || month === 'February' || month === 'March' || month === 'April') {
                 return 2026;
             }
             return 2025;


### PR DESCRIPTION
- Update getYearForMonth() to assign 2026 to January-April
- Previously only Jan-Mar were 2026, causing April to show as 2025
- Fixes current month display to show 'April 2026' correctly
- Ensures proper chronological sorting with April 2026 data