### PR TITLE
feat(opex): Add Shrinkage Qty column to Top 30 Shrinkage table

### DIFF
--- a/opex-dashboard-v2.js
+++ b/opex-dashboard-v2.js
@@ -28,7 +28,8 @@ class OpexDashboardV2 {
             audit: { column: null, direction: 'asc' },
             sttk: { column: null, direction: 'asc' },
             cctv: { column: null, direction: 'asc' },
-            compliance: { column: null, direction: 'asc' }
+            compliance: { column: null, direction: 'asc' },
+            shrinkage: { column: null, direction: 'asc' }
         };
         
         // Filtering state
@@ -773,19 +774,45 @@ class OpexDashboardV2 {
     renderShrinkageSection() {
         console.log('Rendering Shrinkage section with', this.data.shrinkage.length, 'items');
         
-        const tableHtml = this.data.shrinkage.map((item, index) => {
+        let data = [...this.data.shrinkage];
+        
+        // Apply sorting if active
+        const { column, direction } = this.sorting.shrinkage;
+        if (column !== null && direction !== 'asc') {
+            data.sort((a, b) => {
+                let valA, valB;
+                switch(column) {
+                    case 1: valA = a.itemCode; valB = b.itemCode; break;
+                    case 2: valA = a.itemName; valB = b.itemName; break;
+                    case 3: valA = a.qty; valB = b.qty; break;
+                    case 4: valA = a.value; valB = b.value; break;
+                    default: return 0;
+                }
+                
+                if (typeof valA === 'string') {
+                    return direction === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA);
+                } else {
+                    return direction === 'asc' ? valA - valB : valB - valA;
+                }
+            });
+        }
+        // else: keep default sort (by value descending from processShrinkageData)
+        
+        const tableHtml = data.map((item, index) => {
+            const formattedQty = this.formatSttkNumber(item.qty);
             const formattedValue = this.formatSttkCurrency(item.value);
             return `
             <tr>
                 <td>${index + 1}</td>
                 <td>${this.escapeHtml(item.itemCode)}</td>
                 <td>${this.escapeHtml(item.itemName)}</td>
+                <td>${formattedQty}</td>
                 <td><span class="badge badge-red">${formattedValue}</span></td>
             </tr>
         `;
         }).join('');
         
-        this.updateElement('shrinkageItemsTable', tableHtml || '<tr><td colspan="4" class="no-data">No data available</td></tr>');
+        this.updateElement('shrinkageItemsTable', tableHtml || '<tr><td colspan="5" class="no-data">No data available</td></tr>');
     }
 
     renderCctvSection() {

--- a/opex-dashboard.html
+++ b/opex-dashboard.html
@@ -551,12 +551,15 @@
                                 Item Name <i class="fas fa-sort sort-icon"></i>
                             </th>
                             <th class="sortable" onclick="sortTable('shrinkage', 3)">
+                                Shrinkage Qty <i class="fas fa-sort sort-icon"></i>
+                            </th>
+                            <th class="sortable" onclick="sortTable('shrinkage', 4)">
                                 Shrinkage Value <i class="fas fa-sort sort-icon"></i>
                             </th>
                         </tr>
                     </thead>
                     <tbody id="shrinkageItemsTable">
-                        <tr><td colspan="4" class="loading">Loading shrinkage items...</td></tr>
+                        <tr><td colspan="5" class="loading">Loading shrinkage items...</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -949,6 +952,8 @@
                 opexDashboard.renderSttkTable();
             } else if (section === 'cctv') {
                 opexDashboard.renderCctvTable();
+            } else if (section === 'shrinkage') {
+                opexDashboard.renderShrinkageSection();
             }
         }
         


### PR DESCRIPTION
- Added new column 'Shrinkage Qty' before 'Shrinkage Value'
- Display formatted quantity using formatSttkNumber()
- Added sorting support for all columns (Item Code, Name, Qty, Value)
- Updated column count from 4 to 5 in table structure
- Sorting state initialized for shrinkage section
- Updated sortTable() to handle shrinkage section rendering