### PR TITLE
feat(am-tracker): update L1/L2 display to Jt units and add daily gap …

### DIFF
--- a/index.html
+++ b/index.html
@@ -11936,10 +11936,21 @@
                         const l2Achievement = l2Target > 0 ? (forecastSalesEndOfMonth / l2Target) * 100 : 0;
                         const l3Achievement = l3Target > 0 ? (forecastSalesEndOfMonth / l3Target) * 100 : 0;
                         
+                        // Calculate remaining days in month
+                        const today = new Date();
+                        const currentDay = today.getDate();
+                        const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+                        const daysRemaining = Math.max(1, lastDayOfMonth - currentDay); // At least 1 day to avoid division by zero
+                        
                         // Calculate gaps (how much more needed to reach each level)
                         const gapToL1 = Math.max(0, l1Target - forecastSalesEndOfMonth);
                         const gapToL2 = Math.max(0, l2Target - forecastSalesEndOfMonth);
                         const gapToL3 = Math.max(0, l3Target - forecastSalesEndOfMonth);
+                        
+                        // Calculate daily gap requirements (gap divided by remaining days)
+                        const dailyGapL1 = gapToL1 / daysRemaining;
+                        const dailyGapL2 = gapToL2 / daysRemaining;
+                        const dailyGapL3 = gapToL3 / daysRemaining;
                         
                         const record = {
                             outlet,
@@ -11957,6 +11968,10 @@
                             gapToL1,
                             gapToL2,
                             gapToL3,
+                            dailyGapL1,
+                            dailyGapL2,
+                            dailyGapL3,
+                            daysRemaining,
                             growthPercent,
                             forecastPercent: l3Achievement, // Main forecast % is vs L3 target
                             performanceScore: (growthPercent + l3Achievement) / 2,
@@ -12044,10 +12059,18 @@
                         ? (group.totalForecastSales / group.totalL3Target) * 100
                         : 0;
                     
+                    // Calculate remaining days in month (use first outlet's daysRemaining - they all have same value)
+                    const daysRemaining = group.outlets.length > 0 ? group.outlets[0].daysRemaining : 1;
+                    
                     // Calculate gaps (how much more needed to reach each level)
                     const gapToL1 = Math.max(0, group.totalL1Target - group.totalForecastSales);
                     const gapToL2 = Math.max(0, group.totalL2Target - group.totalForecastSales);
                     const gapToL3 = Math.max(0, group.totalL3Target - group.totalForecastSales);
+                    
+                    // Calculate daily gap requirements for AM (total gap / remaining days)
+                    const dailyGapL1 = gapToL1 / daysRemaining;
+                    const dailyGapL2 = gapToL2 / daysRemaining;
+                    const dailyGapL3 = gapToL3 / daysRemaining;
                     
                     return {
                         amName: group.amName,
@@ -12061,6 +12084,10 @@
                         gapToL1,
                         gapToL2,
                         gapToL3,
+                        dailyGapL1,
+                        dailyGapL2,
+                        dailyGapL3,
+                        daysRemaining,
                         totalL1Target: group.totalL1Target,
                         totalL2Target: group.totalL2Target,
                         totalL3Target: group.totalL3Target,
@@ -12220,9 +12247,9 @@
                                     ${this.getPerformanceBadge(am.l3Achievement)}
                                 </div>
                                 <div class="text-xs text-gray-600 space-y-1">
-                                    <div>L3: Rp ${(am.totalL3Target / 1000000).toFixed(1)}M ${am.gapToL3 > 0 ? '(Gap: ' + (am.gapToL3 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
-                                    <div>L2: ${am.l2Achievement.toFixed(1)}% ${am.gapToL2 > 0 ? '(Gap: ' + (am.gapToL2 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
-                                    <div>L1: ${am.l1Achievement.toFixed(1)}% ${am.gapToL1 > 0 ? '(Gap: ' + (am.gapToL1 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
+                                    <div>L3: Rp ${(am.totalL3Target / 1000000000).toFixed(2)}Jt ${am.gapToL3 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL3 / 1000000000).toFixed(2) + 'Jt, Daily: ' + (am.dailyGapL3 / 1000000).toFixed(1) + 'Jt/' + am.daysRemaining + 'd)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L2: Rp ${(am.totalL2Target / 1000000000).toFixed(2)}Jt ${am.gapToL2 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL2 / 1000000000).toFixed(2) + 'Jt, Daily: ' + (am.dailyGapL2 / 1000000).toFixed(1) + 'Jt/' + am.daysRemaining + 'd)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L1: Rp ${(am.totalL1Target / 1000000000).toFixed(2)}Jt ${am.gapToL1 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL1 / 1000000000).toFixed(2) + 'Jt, Daily: ' + (am.dailyGapL1 / 1000000).toFixed(1) + 'Jt/' + am.daysRemaining + 'd)</span>' : '<span class="text-green-600">✓</span>'}</div>
                                 </div>
                             </div>
                         </td>
@@ -12305,9 +12332,9 @@
                                     ${this.getPerformanceBadge(am.l3Achievement)}
                                 </div>
                                 <div class="text-xs text-gray-600">
-                                    <div>L3: ${(am.l3Target / 1000000).toFixed(1)}M ${am.gapToL3 > 0 ? '(Gap: ' + (am.gapToL3 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
-                                    <div>L2: ${am.l2Achievement.toFixed(1)}% ${am.gapToL2 > 0 ? '(Gap: ' + (am.gapToL2 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
-                                    <div>L1: ${am.l1Achievement.toFixed(1)}% ${am.gapToL1 > 0 ? '(Gap: ' + (am.gapToL1 / 1000000).toFixed(1) + 'M)' : '✓'}</div>
+                                    <div>L3: ${(am.l3Target / 1000000000).toFixed(2)}Jt ${am.gapToL3 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL3 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL3 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L2: ${(am.l2Target / 1000000000).toFixed(2)}Jt ${am.gapToL2 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL2 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL2 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L1: ${(am.l1Target / 1000000000).toFixed(2)}Jt ${am.gapToL1 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL1 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL1 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
                                 </div>
                             </div>
                         </td>
@@ -12390,10 +12417,10 @@
                                 </div>
                                 
                                 <div class="text-xs text-gray-600 space-y-1 pt-2 border-t">
-                                    <div class="font-semibold text-gray-700">Target Levels:</div>
-                                    <div>L3: Rp ${(am.l3Target / 1000000).toFixed(1)}M ${am.gapToL3 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL3 / 1000000).toFixed(1) + 'M)</span>' : '<span class="text-green-600">✓</span>'}</div>
-                                    <div>L2: ${am.l2Achievement.toFixed(1)}% ${am.gapToL2 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL2 / 1000000).toFixed(1) + 'M)</span>' : '<span class="text-green-600">✓</span>'}</div>
-                                    <div>L1: ${am.l1Achievement.toFixed(1)}% ${am.gapToL1 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL1 / 1000000).toFixed(1) + 'M)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div class="font-semibold text-gray-700">Target Levels (${am.daysRemaining}d left):</div>
+                                    <div>L3: Rp ${(am.l3Target / 1000000000).toFixed(2)}Jt ${am.gapToL3 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL3 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL3 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L2: Rp ${(am.l2Target / 1000000000).toFixed(2)}Jt ${am.gapToL2 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL2 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL2 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
+                                    <div>L1: Rp ${(am.l1Target / 1000000000).toFixed(2)}Jt ${am.gapToL1 > 0 ? '<span class="text-red-600">(Gap: ' + (am.gapToL1 / 1000000000).toFixed(2) + 'Jt, +' + (am.dailyGapL1 / 1000000).toFixed(1) + 'Jt/d)</span>' : '<span class="text-green-600">✓</span>'}</div>
                                 </div>
                             </div>
                         </div>
@@ -12561,7 +12588,7 @@
                 const am = this.overviewData.find(a => a.amName === amName);
                 if (!am) return;
                 
-                alert(`AM Details: ${amName}\n\nOutlets Managed: ${am.outletCount}\nAverage Growth: ${am.avgGrowth.toFixed(1)}%\n\nTargets & Achievement:\nL3 Target: Rp ${am.totalL3Target.toLocaleString()} (${am.l3Achievement.toFixed(1)}%) ${am.gapToL3 > 0 ? 'Gap: Rp ' + am.gapToL3.toLocaleString() : '✓ Achieved'}\nL2 Target: Rp ${am.totalL2Target.toLocaleString()} (${am.l2Achievement.toFixed(1)}%) ${am.gapToL2 > 0 ? 'Gap: Rp ' + am.gapToL2.toLocaleString() : '✓ Achieved'}\nL1 Target: Rp ${am.totalL1Target.toLocaleString()} (${am.l1Achievement.toFixed(1)}%) ${am.gapToL1 > 0 ? 'Gap: Rp ' + am.gapToL1.toLocaleString() : '✓ Achieved'}\n\nTotal Forecast: Rp ${am.totalForecastSales.toLocaleString()}\n\nOutlets:\n${am.outlets.map(o => `• ${o.outlet} (${o.outletName}): Growth ${o.growthPercent.toFixed(1)}%, Forecast ${o.forecastPercent.toFixed(1)}%`).join('\n')}`);
+                alert(`AM Details: ${amName}\n\nOutlets Managed: ${am.outletCount}\nAverage Growth: ${am.avgGrowth.toFixed(1)}%\nDays Remaining: ${am.daysRemaining} days\n\nTargets & Achievement:\nL3 Target: Rp ${(am.totalL3Target / 1000000000).toFixed(2)}Jt (${am.l3Achievement.toFixed(1)}%)\n${am.gapToL3 > 0 ? '   Gap: Rp ' + (am.gapToL3 / 1000000000).toFixed(2) + 'Jt (Need +' + (am.dailyGapL3 / 1000000).toFixed(1) + 'Jt/day)' : '   ✓ Achieved'}\n\nL2 Target: Rp ${(am.totalL2Target / 1000000000).toFixed(2)}Jt (${am.l2Achievement.toFixed(1)}%)\n${am.gapToL2 > 0 ? '   Gap: Rp ' + (am.gapToL2 / 1000000000).toFixed(2) + 'Jt (Need +' + (am.dailyGapL2 / 1000000).toFixed(1) + 'Jt/day)' : '   ✓ Achieved'}\n\nL1 Target: Rp ${(am.totalL1Target / 1000000000).toFixed(2)}Jt (${am.l1Achievement.toFixed(1)}%)\n${am.gapToL1 > 0 ? '   Gap: Rp ' + (am.gapToL1 / 1000000000).toFixed(2) + 'Jt (Need +' + (am.dailyGapL1 / 1000000).toFixed(1) + 'Jt/day)' : '   ✓ Achieved'}\n\nTotal Forecast: Rp ${(am.totalForecastSales / 1000000000).toFixed(2)}Jt\n\nOutlets:\n${am.outlets.map(o => `• ${o.outlet} (${o.outletName}): Growth ${o.growthPercent.toFixed(1)}%, Forecast ${o.forecastPercent.toFixed(1)}%`).join('\n')}`);
             },
             
             // Filter by specific AM


### PR DESCRIPTION
…calculations

Changes:
- Display L1/L2 targets in Jt (billions) instead of percentages
- Changed all M (millions) to Jt (billions) for consistency
- Calculate remaining days in current month dynamically
- Add daily gap requirements (total gap / remaining days)
- Show daily top-up amount needed to reach each target level

Display Format Updates:
- L3: Rp X.XXJt (Gap: X.XXJt, Daily: X.XJt/Nd)
- L2: Rp X.XXJt (Gap: X.XXJt, Daily: X.XJt/Nd)
- L1: Rp X.XXJt (Gap: X.XXJt, Daily: X.XJt/Nd)
- N = days remaining in month

Calculation Logic:
- Days Remaining = Last Day of Month - Current Day
- Daily Gap = Total Gap / Days Remaining
- Example: If 29 days left and gap is 290Jt, team needs +10Jt/day

Benefits:
- Teams know exact daily targets to close gaps
- Consistent Jt units across all metrics
- Clear actionable daily goals for each level
- Shows days remaining context in card view