### PR TITLE
fix(finance/bri): Kode Rekon day = transaction date - 1 day

### DIFF
--- a/finance/file-rekonsiliasi-splitter.html
+++ b/finance/file-rekonsiliasi-splitter.html
@@ -1045,10 +1045,20 @@ async function processBRI() {
             const dateStr  = cleanCell(row[IDX_DATE]);   // '2026-07-01 03:22:44'
             const desk     = cleanCell(row[IDX_DESK]);
 
-            // Day from date
-            const dateParts = dateStr.split(' ')[0].split('-');   // ['2026','07','01']
-            const day       = dateParts.length === 3 ? parseInt(dateParts[2], 10).toString() : '?';
-            const dateOnly  = dateParts.length === 3 ? dateParts.join('-') : dateStr;
+            // Day from date → subtract 1 day (BRI posts next day; rekon date = txn date - 1)
+            const dateParts = dateStr.split(' ')[0].split('-');   // ['2026','07','02']
+            let day = '?';
+            let dateOnly = dateStr;
+            if (dateParts.length === 3) {
+                const d = new Date(Date.UTC(
+                    parseInt(dateParts[0], 10),
+                    parseInt(dateParts[1], 10) - 1,   // month is 0-based
+                    parseInt(dateParts[2], 10)
+                ));
+                d.setUTCDate(d.getUTCDate() - 1);     // go back 1 day
+                day      = d.getUTCDate().toString();  // e.g. 2/7 → 1,  1/7 → 30
+                dateOnly = d.toISOString().slice(0, 10);
+            }
 
             // MID extraction
             const midMatch = MID_RE.exec(desk);


### PR DESCRIPTION
BRI settles next business day, so the rekon date must go back 1 day:
- 2/7/2026  → day = 1   → Kode Rekon e.g. 1BTTGBR1
- 1/7/2026  → day = 30  → Kode Rekon e.g. 30BTTGBR1 (June has 30 days)
Uses Date.UTC + setUTCDate(-1) so month/year rollover is handled correctly.